### PR TITLE
bug with multi-lines in setup.py and twine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - pip install -r requirements.txt
   - pip install -r tests/requirements.txt
 
-script: flake8 --exclude setup.py *.py tests cli/kubectl-hyperkube && python -m unittest discover -s tests/ -p "*.py"
+script: flake8 *.py tests cli/kubectl-hyperkube && python -m unittest discover -s tests/ -p "*.py"
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - pip install -r requirements.txt
   - pip install -r tests/requirements.txt
 
-script: flake8 *.py tests cli/kubectl-hyperkube && python -m unittest discover -s tests/ -p "*.py"
+script: flake8 --exclude setup.py *.py tests cli/kubectl-hyperkube && python -m unittest discover -s tests/ -p "*.py"
 
 deploy:
   provider: pypi

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,7 @@ from setuptools import find_packages, setup, Command
 
 # Package meta-data.
 NAME = 'hyper-kube-config'
-DESCRIPTION = """H Y P E R K U B E - A secure Serverless API and kubectl plugin
-that stores and retrieve Kubernetes cluster credentials.
-Hyperkube leverages AWS Secrets Manager for storing credential information."""
+DESCRIPTION = """H Y P E R K U B E - A secure Serverless API and kubectl plugin that stores and retrieve Kubernetes cluster credentials. Hyperkube leverages AWS Secrets Manager for storing credential information."""
 URL = 'https://github.com/silvermullet/hyper-kube-config'
 EMAIL = 'zane@ugh.cloud'
 AUTHOR = 'Zane Williamson'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import find_packages, setup, Command
 
 # Package meta-data.
 NAME = 'hyper-kube-config'
-DESCRIPTION = """H Y P E R K U B E - A secure Serverless API and kubectl plugin that stores and retrieve Kubernetes cluster credentials. Hyperkube leverages AWS Secrets Manager for storing credential information."""
+DESCRIPTION = """H Y P E R K U B E - A secure Serverless API and kubectl plugin that stores and retrieve Kubernetes cluster credentials. Hyperkube leverages AWS Secrets Manager for storing credential information.""" # noqa
 URL = 'https://github.com/silvermullet/hyper-kube-config'
 EMAIL = 'zane@ugh.cloud'
 AUTHOR = 'Zane Williamson'


### PR DESCRIPTION
See issue: https://github.com/pypa/setuptools/issues/1390

causes builds to fail: 
https://travis-ci.org/silvermullet/hyper-kube-config/builds/598458648

tested and verified locally:
```
$ twine check dist/*

/Users/zanew/.local/share/virtualenvs/hyper-kube-config-N69MsY20/lib/python3.7/site-packages/readme_renderer/markdown.py:38: UserWarning: Markdown renderers are not available. Install 'readme_render[md]' to enable Markdown rendering.
  warnings.warn(_EXTRA_WARNING)
Checking distribution dist/hyper-kube-config-0.1.5.tar.gz: Failed
The project's long_description has invalid markup which will not be rendered on PyPI. The following syntax errors were detected:
line 8: Error: Unexpected indentation.
```

while single line is ok