### PR TITLE
added serverless function and kubectl hyperkube command to remove pem…

### DIFF
--- a/cli/kubectl-hyperkube
+++ b/cli/kubectl-hyperkube
@@ -195,6 +195,24 @@ def get_pem(ctx, cluster):
 
 
 @cli.command()
+@click.option('--cluster', '-g')
+@click.pass_context
+def remove_pem(ctx, cluster):
+    """Removethe pem file for a specific cluster"""
+
+    try:
+        r = requests.delete(
+            (f'{ctx.obj["url"]}/{ctx.obj["stage"]}'
+             f'/clusters/remove-pem?cluster_name={cluster}'),
+            headers=ctx.obj['headers']
+        )
+        if r.status_code == 404:
+            sys.exit(1)
+    except requests.exceptions.RequestException as err:
+        print(f'Request error: {err}')
+
+
+@cli.command()
 @click.option('--cluster', '-g', required=True)
 @click.option('--pem', '-p', required=True)
 @click.pass_context

--- a/serverless.yml
+++ b/serverless.yml
@@ -110,6 +110,13 @@ functions:
           path: clusters/get-pem
           method: get
           private: true
+  remove_pem:
+    handler: pem.remove_pem
+    events:
+      - http:
+          path: clusters/remove-pem
+          method: delete
+          private: true
   list_clusters:
     handler: list_clusters.list_clusters
     events:


### PR DESCRIPTION
*What:* new endpoint to request to remove pem for a given cluster
*Why:* Pipeline is currenltly not cleaning up pem files from hyperkube when a cluster is deleted.